### PR TITLE
Allow returning to landing page

### DIFF
--- a/src/components/core/App/script.js
+++ b/src/components/core/App/script.js
@@ -67,6 +67,11 @@ function loadState() {
 
 // ----------------------------------------------------------------------------
 
+function navigate() {
+}
+
+// ----------------------------------------------------------------------------
+
 export default {
   name: 'App',
   components: {
@@ -93,8 +98,15 @@ export default {
       errors: [],
     };
   },
+  watch: {
+    landing(landing) {
+      window.location.hash = landing ? '' : '#app';
+    },
+  },
   mounted() {
+    window.addEventListener('hashchange', this.navigate);
     window.addEventListener('error', this.recordError);
+
     if (window.console) {
       this.origConsoleError = window.console.error;
       window.console.error = (...args) => {
@@ -104,7 +116,9 @@ export default {
     }
   },
   beforeDestroy() {
+    window.removeEventListener('hashchange', this.navigate);
     window.removeEventListener('error', this.recordError);
+
     if (this.origConsoleError) {
       window.console.error = this.origConsoleError;
     }
@@ -112,6 +126,9 @@ export default {
   methods: {
     saveState,
     loadState,
+    navigate() {
+      this.landing = window.location.hash !== '#app';
+    },
     recordError(error) {
       this.errors.push(error);
     },

--- a/src/components/core/App/template.html
+++ b/src/components/core/App/template.html
@@ -23,7 +23,16 @@
         @click.native.stop="controlsDrawer = !controlsDrawer"
       />
       <!-- smaller than height of the toolbar -->
-      <svg-icon icon="paraview-glance" height="52px" />
+      <v-tooltip bottom :disabled="landing">
+        <a
+          slot="activator"
+          href="#"
+          v-on:click.prevent="landing = true"
+        >
+          <svg-icon icon="paraview-glance" height="52px" />
+        </a>
+        <span>Back to landing page</span>
+      </v-tooltip>
       <v-spacer />
       <v-btn
         v-if="errors.length"


### PR DESCRIPTION
Clicking the logo will return to landing page, and a button will pop up allowing you to return to the app from the landing page.

I'm thinking of also adding browser history hooks so back/forward works for this as well.

@agirault 