### PR TITLE
fix(VtkView): Do not set view container on update

### DIFF
--- a/src/components/core/VtkView/script.js
+++ b/src/components/core/VtkView/script.js
@@ -373,7 +373,4 @@ export default {
       this.changeViewType(DEFAULT_VIEW_TYPE);
     }
   },
-  updated() {
-    this.view.setContainer(this.$el.querySelector('.js-view'));
-  },
 };


### PR DESCRIPTION
view.setContainer() unbinds the vtkjs mouseup listener, causing "sticky"
widget interaction.

Fixes #114 