### PR TITLE
Use comma as thousands separator

### DIFF
--- a/src/components/controls/Information/PolyData/template.html
+++ b/src/components/controls/Information/PolyData/template.html
@@ -9,11 +9,11 @@
   <v-card-text :class="$style.blockContent">
     <v-layout row>
       <v-flex xs6 class="body-1">Number of points:</v-flex>
-      <v-flex xs6 class="body-1" :class="$style.canSelect">{{ formatNumbersWithThousandSeparator(dataset.getPoints().getNumberOfPoints()) }}</v-flex>
+      <v-flex xs6 class="body-1" :class="$style.canSelect">{{ formatNumbersWithThousandSeparator(dataset.getPoints().getNumberOfPoints(), ',') }}</v-flex>
     </v-layout>
     <v-layout row>
       <v-flex xs6 class="body-1">Number of cells:</v-flex>
-      <v-flex xs6 class="body-1" :class="$style.canSelect">{{ formatNumbersWithThousandSeparator(dataset.getNumberOfCells()) }}</v-flex>
+      <v-flex xs6 class="body-1" :class="$style.canSelect">{{ formatNumbersWithThousandSeparator(dataset.getNumberOfCells(), ',') }}</v-flex>
     </v-layout>
   </v-card-text>
 </v-card>


### PR DESCRIPTION
Partially addresses #144. The FPS monitor requires a vtk.js change.

This uses commas for now to avoid text wrap, as the used spaces are not non-breaking.