### PR TITLE
fix(ReaderFactory): Support file extensions with additional .gz

### DIFF
--- a/documentation/content/doc/readers.md
+++ b/documentation/content/doc/readers.md
@@ -25,25 +25,25 @@ table {
 
 ## ITK.js
 
-The only structure that can be loaded by ITK.js are vtkImageData.
+The only structure that currently can be loaded by ITK.js are vtkImageData.
 This means that the `Legacy VTK (*.vtk)` format won't work for vtkPolyData, vtkUnstructuredGrid...
 
-| Extension           | Module         |
-| ------------------- | -------------- |
-| *.bmp               | itkBMPImage    |
-| *.dcm               | itkDCMTKImage  |
-| *.gipl, gipl.gz     | itkGiplImage   |
-| *.hdf5              | itkHDF5Image   |
-| *.jpg, *.jpeg       | itkJPEGImage   |
-| *.json              | itkJSONImage   |
-| *.lsm               | itkLSMImage    |
-| *.mnc, *.mnc2       | itkMINCImage   |
-| *.mgh, *.mgz        | itkMGHImage    |
-| *.mha, *.mhd        | itkMetaImage   |
-| *.mrc               | itkMRCImage    |
-| *.nia, *.nii, *.hdr | itkNiftiImage  |
-| *.nrrd, *.nhdr      | itkNrrdImage   |
-| *.png               | itkPNGImage    |
-| *.pic               | itkBioRadImage |
-| *.tif, *.tiff       | itkTIFFImage   |
-| *.vtk               | itkVTKImage    |
+| Extension                     | Module         |
+| ----------------------------- | -------------- |
+| *.bmp                         | itkBMPImage    |
+| *.dcm                         | itkDCMTKImage  |
+| *.gipl, gipl.gz               | itkGiplImage   |
+| *.hdf5                        | itkHDF5Image   |
+| *.jpg, *.jpeg                 | itkJPEGImage   |
+| *.json                        | itkJSONImage   |
+| *.lsm                         | itkLSMImage    |
+| *.mnc, *.mnc.gz,*.mnc2        | itkMINCImage   |
+| *.mgh, *.mgz, *.mgh.gz        | itkMGHImage    |
+| *.mha, *.mhd                  | itkMetaImage   |
+| *.mrc                         | itkMRCImage    |
+| *.nia, *.nii, *.hdr, *.nii.gz | itkNiftiImage  |
+| *.nrrd, *.nhdr                | itkNrrdImage   |
+| *.png                         | itkPNGImage    |
+| *.pic                         | itkBioRadImage |
+| *.tif, *.tiff                 | itkTIFFImage   |
+| *.vtk                         | itkVTKImage    |

--- a/src/io/ReaderFactory.js
+++ b/src/io/ReaderFactory.js
@@ -32,10 +32,13 @@ function registerReader({
 }
 
 function getReader({ name }) {
-  const ext = name
-    .split('.')
-    .pop()
-    .toLowerCase();
+  /* eslint no-bitwise: ["error", { "allow": [">>>"] }] */
+  let ext = name.toLowerCase().slice(((name.lastIndexOf('.') - 1) >>> 0) + 2);
+  if (ext === 'gz') {
+    const index = name.slice(0, -3).lastIndexOf('.');
+    /* eslint no-bitwise: ["error", { "allow": [">>>"] }] */
+    ext = name.slice(((index - 1) >>> 0) + 2);
+  }
   return READER_MAPPING[ext];
 }
 


### PR DESCRIPTION
For example, *.nii.gz.

Adapted from itk.js/getFileExtension.js

Also update itk.js supported extensions in the documentation.