### PR TITLE
fix(package.json): Upgrade mousetrap and force a new release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12972,9 +12972,9 @@
       }
     },
     "mousetrap": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.2.tgz",
-      "integrity": "sha512-jDjhi7wlHwdO6q6DS7YRmSHcuI+RVxadBkLt3KHrhd3C2b+w5pKefg3oj5beTcHZyVFA9Aksf+yEE1y5jxUjVA=="
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/mousetrap/-/mousetrap-1.6.3.tgz",
+      "integrity": "sha512-bd+nzwhhs9ifsUrC2tWaSgm24/oo2c83zaRyZQF06hYA6sANfsXHtnZ19AbbbDXCDzeH5nZBSQ4NvCjgD62tJA=="
     },
     "move-concurrently": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@linusborg/vue-simple-portal": "^0.1.3",
     "itk": "9.1.1",
     "material-design-icons-iconfont": "4.0.2",
-    "mousetrap": "^1.6.2",
+    "mousetrap": "^1.6.3",
     "typeface-roboto": "0.0.54",
     "vtk.js": "11.9.1",
     "vue": "2.6.6",


### PR DESCRIPTION
The previous commit should have been a fix(), but I typed "chore".