### PR TITLE
fix(ITKReader): Dicom should be downloaded as binary

### DIFF
--- a/externals/ITKReader/index.js
+++ b/externals/ITKReader/index.js
@@ -53,6 +53,7 @@ export function registerToGlance(Glance) {
       vtkReader: vtkITKDicomImageReader,
       fileNameMethod: 'setFileName',
       fileSeriesMethod: 'readFileSeries',
+      binary: true,
     });
   }
 }


### PR DESCRIPTION
Corresponding issue: https://discourse.paraview.org/t/paraview-glance-cannot-load-dcm-files-error-could-not-read-file-work-x-dcm/3342