### PR TITLE
Sync settings with store

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -21,6 +21,8 @@ import App from 'paraview-glance/src/components/core/App';
 import Config from 'paraview-glance/src/config';
 import createStore from 'paraview-glance/src/store';
 import { ProxyManagerVuePlugin } from 'paraview-glance/src/plugins';
+import Settings from 'paraview-glance/src/settings';
+import { curry } from 'paraview-glance/src/utils';
 
 // Expose IO API to Glance global object
 export const {
@@ -88,6 +90,14 @@ export function createViewer(container, proxyConfig = null) {
   );
   window.history.replaceState({ app: false }, '');
   window.addEventListener('popstate', onRoute);
+
+  const settings = new Settings();
+  settings.syncWithStore(store, {
+    collapseDatasetPanels: {
+      set: curry(2, store.dispatch)('collapseDatasetPanels'),
+      get: (state) => state.collapseDatasetPanels,
+    },
+  });
 
   return {
     processURLArgs() {

--- a/src/app.js
+++ b/src/app.js
@@ -100,6 +100,8 @@ export function createViewer(container, proxyConfig = null) {
   });
 
   return {
+    proxyManager,
+
     processURLArgs() {
       const { name, url } = vtkURLExtract.extractURLParameters();
       if (name && url) {
@@ -112,9 +114,14 @@ export function createViewer(container, proxyConfig = null) {
     addDatasetPanel(component) {
       store.commit('addPanel', { component });
     },
-    proxyManager,
     showApp() {
       store.commit('showApp');
+    },
+    getSetting(name) {
+      return settings.get(name);
+    },
+    setSetting(name, value) {
+      return settings.set(name, value);
     },
   };
 }

--- a/src/app.js
+++ b/src/app.js
@@ -97,6 +97,10 @@ export function createViewer(container, proxyConfig = null) {
       set: curry(2, store.dispatch)('collapseDatasetPanels'),
       get: (state) => state.collapseDatasetPanels,
     },
+    suppressBrowserWarning: {
+      set: curry(2, store.dispatch)('suppressBrowserWarning'),
+      get: (state) => state.suppressBrowserWarning,
+    },
   });
 
   return {

--- a/src/app.js
+++ b/src/app.js
@@ -22,7 +22,6 @@ import Config from 'paraview-glance/src/config';
 import createStore from 'paraview-glance/src/store';
 import { ProxyManagerVuePlugin } from 'paraview-glance/src/plugins';
 import Settings from 'paraview-glance/src/settings';
-import { curry } from 'paraview-glance/src/utils';
 
 // Expose IO API to Glance global object
 export const {
@@ -94,11 +93,11 @@ export function createViewer(container, proxyConfig = null) {
   const settings = new Settings();
   settings.syncWithStore(store, {
     collapseDatasetPanels: {
-      set: curry(2, store.dispatch)('collapseDatasetPanels'),
+      set: (val) => store.dispatch('collapseDatasetPanels', val),
       get: (state) => state.collapseDatasetPanels,
     },
     suppressBrowserWarning: {
-      set: curry(2, store.dispatch)('suppressBrowserWarning'),
+      set: (val) => store.dispatch('suppressBrowserWarning', val),
       get: (state) => state.suppressBrowserWarning,
     },
   });

--- a/src/components/core/BrowserIssues/script.js
+++ b/src/components/core/BrowserIssues/script.js
@@ -1,4 +1,4 @@
-const WARNING_KEY = 'BrowserIssues.suppressWarning';
+import { mapState, mapActions } from 'vuex';
 
 // ----------------------------------------------------------------------------
 // Component API
@@ -24,18 +24,9 @@ function getBrowserIssues() {
     // }
   }
 
-  if (Object.keys(this.issues).length && !this.suppressWarning) {
+  if (Object.keys(this.issues).length && !this.suppressBrowserWarning) {
     this.dialog = true;
   }
-}
-
-// ----------------------------------------------------------------------------
-
-function closeDialog() {
-  if (this.suppressWarning && window.localStorage) {
-    window.localStorage.setItem(WARNING_KEY, true);
-  }
-  this.dialog = false;
 }
 
 // ----------------------------------------------------------------------------
@@ -46,20 +37,16 @@ export default {
     return {
       issues: {},
       dialog: false,
-      dontShow: false,
-      suppressWarning: false,
     };
   },
-  created() {
-    if (window.localStorage) {
-      this.suppressWarning = !!window.localStorage.getItem(WARNING_KEY);
-    }
-  },
+  computed: mapState(['suppressBrowserWarning']),
   mounted() {
     this.getBrowserIssues();
   },
   methods: {
-    closeDialog,
     getBrowserIssues,
+    ...mapActions({
+      setSuppressBrowserWarning: 'suppressBrowserWarning',
+    }),
   },
 };

--- a/src/components/core/BrowserIssues/template.html
+++ b/src/components/core/BrowserIssues/template.html
@@ -22,14 +22,15 @@
     </v-card-text>
     <v-card-actions class="d-flex justify-space-between align-center pa-5">
       <v-checkbox
-        v-model="suppressWarning"
         label="Don't show again"
         class="mt-0 pt-0"
         hide-details
+        :value="suppressBrowserWarning"
+        @input="setSuppressBrowserWarning"
       />
       <v-btn
         color="primary"
-        v-on:click="closeDialog"
+        v-on:click="dialog = false"
       >
         Okay
       </v-btn>

--- a/src/components/core/Datasets/script.js
+++ b/src/components/core/Datasets/script.js
@@ -20,6 +20,7 @@ export default {
   },
   computed: {
     ...mapState({
+      collapseDatasetPanels: 'collapseDatasetPanels',
       panels: (state) => {
         const priorities = Object.keys(state.panels).map((n) => Number(n));
         priorities.sort((a, b) => a - b);
@@ -96,12 +97,16 @@ export default {
         const proxy = sources[i];
         const proxyId = proxy.getProxyId();
         if (!(proxyId in this.internalPanelState)) {
-          this.internalPanelState[proxyId] = true;
+          this.internalPanelState[proxyId] = !this.collapseDatasetPanels;
         }
         if (!(proxyId in this.subpanels)) {
-          this.subpanels[proxyId] = Controls.filter((c) => c.visible(proxy))
-            .map((c, j) => (c.defaultExpand ? j : -1))
-            .filter((v) => v > -1);
+          if (this.collapseDatasetPanels) {
+            this.subpanels[proxyId] = [];
+          } else {
+            this.subpanels[proxyId] = Controls.filter((c) => c.visible(proxy))
+              .map((c, j) => (c.defaultExpand ? j : -1))
+              .filter((v) => v > -1);
+          }
         }
       }
 

--- a/src/components/core/GlobalSettings/script.js
+++ b/src/components/core/GlobalSettings/script.js
@@ -53,6 +53,14 @@ export default {
     };
   },
   computed: {
+    collapseDatasetPanelsModel: {
+      get() {
+        return this.collapseDatasetPanels;
+      },
+      set(v) {
+        this.setCollapseDatasetPanels(v);
+      },
+    },
     backgroundColorModel: {
       get() {
         return this.backgroundColor;
@@ -126,6 +134,7 @@ export default {
         this.setMaxTextureLODSize(size);
       },
     },
+    ...mapState(['collapseDatasetPanels']),
     ...mapState('views', {
       backgroundColor: (state) => state.globalBackgroundColor,
       orientationAxis: (state) => state.axisVisible,
@@ -192,6 +201,9 @@ export default {
         }
       }
     },
+    ...mapActions({
+      setCollapseDatasetPanels: 'collapseDatasetPanels',
+    }),
     ...mapActions('views', {
       setBackgroundColor: (dispatch, bg) => dispatch('setGlobalBackground', bg),
       setOrientationAxis: (dispatch, axis) => dispatch('setAxisVisible', axis),

--- a/src/components/core/GlobalSettings/template.html
+++ b/src/components/core/GlobalSettings/template.html
@@ -1,6 +1,26 @@
 <v-container :class="$style.container">
   <v-card flat :class="$style.card">
     <div :class="$style.heading">
+      <span class="subtitle-2">General Settings</span>
+    </div>
+    <v-divider class="mb-4" />
+    <v-container grid-list-xs class="pa-0">
+      <v-layout row align-center class="pt-1">
+        <v-flex xs10>
+          <span class="body-2">Default collapse datasets</span>
+        </v-flex>
+        <v-flex xs2>
+          <v-switch
+            v-model="collapseDatasetPanelsModel"
+            :class="$style.slimInput"
+            hide-details
+          />
+        </v-flex>
+      </v-layout>
+    </v-container>
+  </v-card>
+  <v-card flat :class="$style.card">
+    <div :class="$style.heading">
       <span class="subtitle-2">Background</span>
     </div>
     <v-divider class="mb-4" />

--- a/src/settings.js
+++ b/src/settings.js
@@ -1,0 +1,61 @@
+function callAndEmpty(l) {
+  while (l.length) {
+    l.pop()();
+  }
+}
+
+export default class Settings {
+  constructor(keyPrefix = 'settings') {
+    this.keyPrefix = keyPrefix;
+    this.storeSettingsMap = {};
+    this.store = null;
+    this.storeWatchers = [];
+  }
+
+  key(name) {
+    if (this.keyPrefix) {
+      return `${this.keyPrefix}.${name}`;
+    }
+    return name;
+  }
+
+  get(name) {
+    const result = window.localStorage.getItem(this.key(name));
+    if (result === null) {
+      return undefined;
+    }
+    return JSON.parse(result);
+  }
+
+  set(name, value) {
+    return window.localStorage.setItem(this.key(name), JSON.stringify(value));
+  }
+
+  syncWithStore(store, syncInfo) {
+    callAndEmpty(this.storeWatchers);
+    this.store = store;
+    this.storeSettingsMap = syncInfo;
+
+    const settingNames = Object.keys(syncInfo);
+    // localStorage -> store
+    settingNames.forEach((name) => {
+      const value = this.get(name);
+      if (value !== undefined) {
+        const { set } = syncInfo[name];
+        set(value);
+      }
+    });
+
+    // store -> localStorage
+    this.storeWatchers = settingNames.map((name) => {
+      const { get } = syncInfo[name];
+      return store.watch(get, (value) => this.set(name, value));
+    });
+  }
+
+  delete() {
+    callAndEmpty(this.storeWatchers);
+    this.storeSettingsMap = {};
+    this.store = null;
+  }
+}

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -127,8 +127,8 @@ function createStore(pxm = null) {
       collapseDatasetPanels(state, value) {
         state.collapseDatasetPanels = value;
       },
-      suppressBrowserWarning(state) {
-        state.suppressBrowserWarning = true;
+      suppressBrowserWarning(state, value) {
+        state.suppressBrowserWarning = value;
       },
     },
     actions: {

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -75,6 +75,7 @@ function createStore(pxm = null) {
       panels: {},
       cameraViewPoints: {},
       mostRecentViewPoint: null,
+      collapseDatasetPanels: false,
     },
     getters: {
       proxyManager(state) {
@@ -122,10 +123,14 @@ function createStore(pxm = null) {
       mostRecentViewPoint(state, viewPoint) {
         state.mostRecentViewPoint = viewPoint;
       },
+      collapseDatasetPanels(state, value) {
+        state.collapseDatasetPanels = value;
+      },
     },
     actions: {
       addPanel: wrapMutationAsAction('addPanel'),
       closeScreenshotDialog: wrapMutationAsAction('closeScreenshotDialog'),
+      collapseDatasetPanels: wrapMutationAsAction('collapseDatasetPanels'),
       saveState({ commit, state }, fileNameToUse) {
         const t = new Date();
         const fileName =

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -76,6 +76,7 @@ function createStore(pxm = null) {
       cameraViewPoints: {},
       mostRecentViewPoint: null,
       collapseDatasetPanels: false,
+      suppressBrowserWarning: false,
     },
     getters: {
       proxyManager(state) {
@@ -126,11 +127,15 @@ function createStore(pxm = null) {
       collapseDatasetPanels(state, value) {
         state.collapseDatasetPanels = value;
       },
+      suppressBrowserWarning(state) {
+        state.suppressBrowserWarning = true;
+      },
     },
     actions: {
       addPanel: wrapMutationAsAction('addPanel'),
       closeScreenshotDialog: wrapMutationAsAction('closeScreenshotDialog'),
       collapseDatasetPanels: wrapMutationAsAction('collapseDatasetPanels'),
+      suppressBrowserWarning: wrapMutationAsAction('suppressBrowserWarning'),
       saveState({ commit, state }, fileNameToUse) {
         const t = new Date();
         const fileName =

--- a/src/utils.js
+++ b/src/utils.js
@@ -56,10 +56,26 @@ export function remapIdList(list, mapping) {
   });
 }
 
+/**
+ * Curries a function.
+ */
+export function curry(arity, fn) {
+  const appliedArgs = [];
+  const curriedFn = (...args) => {
+    appliedArgs.push(...args);
+    if (appliedArgs.length >= arity) {
+      return fn(...appliedArgs.slice(0, arity));
+    }
+    return curriedFn;
+  };
+  return curriedFn;
+}
+
 export default {
   makeSubManager,
   wrapSub,
   wrapMutationAsAction,
   remapIdKeys,
   remapIdList,
+  curry,
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -56,26 +56,10 @@ export function remapIdList(list, mapping) {
   });
 }
 
-/**
- * Curries a function.
- */
-export function curry(arity, fn) {
-  const appliedArgs = [];
-  const curriedFn = (...args) => {
-    appliedArgs.push(...args);
-    if (appliedArgs.length >= arity) {
-      return fn(...appliedArgs.slice(0, arity));
-    }
-    return curriedFn;
-  };
-  return curriedFn;
-}
-
 export default {
   makeSubManager,
   wrapSub,
   wrapMutationAsAction,
   remapIdKeys,
   remapIdList,
-  curry,
 };


### PR DESCRIPTION
This adds a settings module, which provides persistent settings that is specific to each user's browser.

This also adds `Glance.setSetting(name, value)` and `Glance.getSetting(name)` to the external API. In addition, there is a new setting `collapseDatasetPanels`, which toggles whether the dataset panel defaults to collapsed or not at startup.