### PR TITLE
chore: Enforce LF line endings in the repo

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -3,4 +3,5 @@ module.exports = {
   singleQuote: true,
   trailingComma: 'es5',
   arrowParens: 'always',
+  endOfLine: 'lf',
 };


### PR DESCRIPTION
Enforces LF endings when linting for this repo, and tell git to checkout using LF line endings. Should fix #299