### PR TITLE
fix: can't choose nii.gz on macOS

### DIFF
--- a/src/store/fileLoader.js
+++ b/src/store/fileLoader.js
@@ -9,7 +9,7 @@ import postProcessDataset from 'paraview-glance/src/io/postProcessing';
 // ----------------------------------------------------------------------------
 
 function getSupportedExtensions() {
-  return ['zip', 'raw', 'glance'].concat(
+  return ['zip', 'raw', 'glance', 'gz'].concat(
     ReaderFactory.listSupportedExtensions()
   );
 }


### PR DESCRIPTION
for xxx.nii.gz, macOS recognize it's extension name as `gz` instead of `nii.gz`