### PR TITLE
Save opacity and don't reset camera on state load

### DIFF
--- a/src/components/controls/SliceControl/script.js
+++ b/src/components/controls/SliceControl/script.js
@@ -64,31 +64,7 @@ function isSliceAvailable(name) {
 
 // ----------------------------------------------------------------------------
 
-function updateOpacity() {
-  // Look on the representations
-  const sliceReps = this.$proxyManager
-    .getRepresentations()
-    .filter(
-      (r) =>
-        r.getInput() === this.source && r.isA('vtkSliceRepresentationProxy')
-    );
-  for (let i = 0; i < sliceReps.length; i++) {
-    sliceReps[i]
-      .getActors()
-      .map((actor) => actor.getProperty())
-      .filter((property) => property.isA('vtkImageProperty'))
-      .forEach((property) => property.setOpacity(this.opacity));
-  }
-}
-
-// ----------------------------------------------------------------------------
-
-const OPTS = {
-  onUpdate: ['updateOpacity'],
-  onChange: {
-    opacity: 'updateOpacity',
-  },
-};
+const OPTS = {};
 
 // ----------------------------------------------------------------------------
 // Add custom method
@@ -97,7 +73,6 @@ const OPTS = {
 const component = helper.generateComponent('SliceControl', FIELDS, true, OPTS);
 Object.assign(component.methods, {
   isSliceAvailable,
-  updateOpacity,
 });
 
 export default component;

--- a/src/components/core/LayoutView/script.js
+++ b/src/components/core/LayoutView/script.js
@@ -42,20 +42,6 @@ export default {
     },
     ...mapActions('views', ['updateLayout']),
   },
-  proxyManagerHooks: {
-    onProxyCreated({ proxyGroup, proxyName }) {
-      // reset cameras when first trivial producer source is added
-      if (
-        proxyGroup === 'Sources' &&
-        proxyName === 'TrivialProducer' &&
-        this.$proxyManager
-          .getSources()
-          .filter((s) => s.getProxyName() === 'TrivialProducer').length === 1
-      ) {
-        this.$proxyManager.resetCameraInAllViews();
-      }
-    },
-  },
   updated() {
     this.$proxyManager.resizeAllViews();
   },

--- a/src/components/core/VtkView/script.js
+++ b/src/components/core/VtkView/script.js
@@ -116,6 +116,7 @@ export default {
     },
     onActiveSourceChange(source) {
       if (
+        source &&
         source.getProxyName() === 'TrivialProducer' &&
         this.view.bindRepresentationToManipulator
       ) {

--- a/src/config/proxy.js
+++ b/src/config/proxy.js
@@ -6,7 +6,6 @@ import vtkLookupTableProxy from 'vtk.js/Sources/Proxy/Core/LookupTableProxy';
 import vtkMoleculeRepresentationProxy from 'vtk.js/Sources/Proxy/Representations/MoleculeRepresentationProxy';
 import vtkPiecewiseFunctionProxy from 'vtk.js/Sources/Proxy/Core/PiecewiseFunctionProxy';
 import vtkProxySource from 'vtk.js/Sources/Proxy/Core/SourceProxy';
-import vtkSliceRepresentationProxy from 'vtk.js/Sources/Proxy/Representations/SliceRepresentationProxy';
 import vtkView from 'vtk.js/Sources/Proxy/Core/ViewProxy';
 import vtkVolumeRepresentationProxy from 'vtk.js/Sources/Proxy/Representations/VolumeRepresentationProxy';
 
@@ -16,6 +15,7 @@ import vtkDistance2DWidget from 'paraview-glance/src/vtk/Distance2DWidget';
 import vtkTextWidget from 'paraview-glance/src/vtk/TextWidget';
 import vtkPaintWidget from 'vtk.js/Sources/Widgets/Widgets3D/PaintWidget';
 
+import vtkCustomSliceRepresentationProxy from 'paraview-glance/src/vtk/CustomSliceRepresentationProxy';
 import vtkLabelMapVolumeRepProxy from 'paraview-glance/src/vtk/LabelMapVolumeRepProxy';
 import vtkLabelMapSliceRepProxy from 'paraview-glance/src/vtk/LabelMapSliceRepProxy';
 import vtkWidgetProxy from 'paraview-glance/src/vtk/WidgetProxy';
@@ -120,12 +120,12 @@ export default {
         proxyLinks.Skybox
       ),
       Slice: createProxyDefinition(
-        vtkSliceRepresentationProxy,
+        vtkCustomSliceRepresentationProxy,
         proxyUI.Slice,
         proxyLinks.Slice
       ),
       SliceX: createProxyDefinition(
-        vtkSliceRepresentationProxy,
+        vtkCustomSliceRepresentationProxy,
         proxyUI.Slice,
         [
           {
@@ -137,7 +137,7 @@ export default {
         ].concat(proxyLinks.Slice)
       ),
       SliceY: createProxyDefinition(
-        vtkSliceRepresentationProxy,
+        vtkCustomSliceRepresentationProxy,
         proxyUI.Slice,
         [
           {
@@ -149,7 +149,7 @@ export default {
         ].concat(proxyLinks.Slice)
       ),
       SliceZ: createProxyDefinition(
-        vtkSliceRepresentationProxy,
+        vtkCustomSliceRepresentationProxy,
         proxyUI.Slice,
         [
           {

--- a/src/config/proxyUI.js
+++ b/src/config/proxyUI.js
@@ -91,6 +91,10 @@ const Slice = [
     name: 'slice',
     domain: { min: 0, max: 255, step: 1 },
   },
+  {
+    name: 'opacity',
+    domain: { min: 0, max: 1, step: 0.01 },
+  },
 ];
 
 const Molecule = [

--- a/src/vtk/CustomSliceRepresentationProxy/index.js
+++ b/src/vtk/CustomSliceRepresentationProxy/index.js
@@ -1,0 +1,52 @@
+import macro from 'vtk.js/Sources/macro';
+import vtkSliceRepresentationProxy from 'vtk.js/Sources/Proxy/Representations/SliceRepresentationProxy';
+
+// ----------------------------------------------------------------------------
+// vtkCustomSliceRepresentationProxy methods
+// ----------------------------------------------------------------------------
+
+function vtkCustomSliceRepresentationProxy(publicAPI, model) {
+  // Set our className
+  model.classHierarchy.push('vtkCustomSliceRepresentationProxy');
+
+  const superClass = { ...publicAPI };
+
+  publicAPI.setOpacity = (opacity) => {
+    if (opacity >= 0 && opacity <= 1 && superClass.setOpacity(opacity)) {
+      model.property.setOpacity(opacity);
+    }
+  };
+}
+
+// ----------------------------------------------------------------------------
+// Object factory
+// ----------------------------------------------------------------------------
+
+const DEFAULT_VALUES = {
+  opacity: 1,
+};
+
+// ----------------------------------------------------------------------------
+
+export function extend(publicAPI, model, initialValues = {}) {
+  Object.assign(model, DEFAULT_VALUES, initialValues);
+
+  // Object methods
+  vtkSliceRepresentationProxy.extend(publicAPI, model);
+
+  macro.setGet(publicAPI, model, ['opacity']);
+
+  // Object specific methods
+  vtkCustomSliceRepresentationProxy(publicAPI, model);
+}
+
+// ----------------------------------------------------------------------------
+
+export const newInstance = macro.newInstance(
+  extend,
+  'vtkCustomSliceRepresentationProxy'
+);
+
+// ----------------------------------------------------------------------------
+
+export default { newInstance, extend };


### PR DESCRIPTION
Fixes #346 
- Opacity is now saved in state files
- Removed extraneous camera reset
- Guard against null source change