### PR TITLE
chore(travis): Workaround travis to get green deploys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,6 @@ notifications:
 cache:
   directories:
     - "$HOME/.npm"
-    - documentation/build-tmp
 
 before_install:
   - sudo apt-get -qq update

--- a/build/travis-release.sh
+++ b/build/travis-release.sh
@@ -16,4 +16,5 @@ npm run semantic-release
 npm run bundle
 
 # Generate website
+rm -rf documentation/build-tmp
 npm run doc:publish


### PR DESCRIPTION
This will blow away the build-tmp cache, forcing a re-build.