### PR TITLE
fix(PaintTool): Place paint widget in image bounds

### DIFF
--- a/src/components/tools/PaintTool/script.js
+++ b/src/components/tools/PaintTool/script.js
@@ -454,6 +454,9 @@ export default {
     enablePainting() {
       const paintProxy = this.$proxyManager.createProxy('Widgets', 'Paint');
       paintProxy.getWidget().setRadius(this.radius);
+      paintProxy
+        .getWidget()
+        .placeWidget(this.activeLabelmapProxy.getDataset().getBounds());
 
       this.widgetId = paintProxy.getProxyId();
       this.mousedViewId = -1;


### PR DESCRIPTION
The paint widget needs to be placed within the bounds of the image to
avoid extending the bounds unnecessarily.

Fixes #365