### PR TITLE
fix(tools): Place widgets in correct bounds

### DIFF
--- a/src/components/tools/CropTool/script.js
+++ b/src/components/tools/CropTool/script.js
@@ -59,6 +59,9 @@ export default {
         const imageData = this.targetVolume.getDataset();
         widget.copyImageDataDescription(imageData);
 
+        // set widget bounds
+        widget.placeWidget(imageData.getBounds());
+
         // if the crop filter is resettable, that means we have
         // cropping planes to use.
         if (cropFilter.isResetAvailable()) {

--- a/src/components/tools/MeasurementTools/tools/ToolTemplate2D.js
+++ b/src/components/tools/MeasurementTools/tools/ToolTemplate2D.js
@@ -167,6 +167,12 @@ export default (toolName, extraComponent = {}) => ({
   },
   methods: {
     addWidgetToViews(proxy) {
+      if (this.targetProxy) {
+        proxy
+          .getWidget()
+          .placeWidget(this.targetProxy.getDataset().getBounds());
+      }
+
       const view3dHandler = (view, widgetManager, viewWidget) => {
         widgetManager.removeWidget(viewWidget);
       };


### PR DESCRIPTION
Placing widgets in bounds allows for correct computation of scene
bounds.