### PR TITLE
fix(glancevtkjsreader): normalize opacity pwf nodes before adding them

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18735,7 +18735,6 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/shader-loader/-/shader-loader-1.3.1.tgz",
       "integrity": "sha512-dt8F9K0x4rjmaFyHh7rNDfpt4LUiR64zhNIEwp2WbE99B3z4ALuvvmhftkElg93dUD6sTmv/aXa/z9SJiEddcA==",
-      "dev": true,
       "requires": {
         "loader-utils": "^1.1.0"
       }
@@ -21451,31 +21450,62 @@
       "integrity": "sha1-YU9/v42AHwu18GYfWy9XhXUOTwk="
     },
     "vtk.js": {
-      "version": "15.4.0",
-      "resolved": "https://registry.npmjs.org/vtk.js/-/vtk.js-15.4.0.tgz",
-      "integrity": "sha512-nf5qt0ex8Mk7jnE07JOLadFSkm5nMVSkEUE3iaVhqqXooHKfj2spBp7UJkSx/TD7gklFK6cm7A8Yoq0w2kg2HA==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/vtk.js/-/vtk.js-16.2.0.tgz",
+      "integrity": "sha512-kd4uXsbMy5rE3pYTyNxrDVtibXuuocZrW1R8AzMNPDicZSEwa/E0ZKyjnlmXWHr7tIt2UFaMpyn25sad6Abzvw==",
       "requires": {
         "blueimp-md5": "2.18.0",
-        "commander": "6.2.0",
+        "commander": "6.2.1",
         "gl-matrix": "3.3.0",
         "jszip": "3.2.0",
-        "pako": "1.0.11",
+        "pako": "2.0.2",
         "seedrandom": "3.0.5",
+        "shader-loader": "1.3.1",
         "shelljs": "0.8.4",
         "webvr-polyfill": "0.10.12",
         "webworker-promise": "0.4.2",
+        "worker-loader": "3.0.7",
         "xmlbuilder": "15.1.1"
       },
       "dependencies": {
+        "@types/json-schema": {
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
+          "integrity": "sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA=="
+        },
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ajv-keywords": {
+          "version": "3.5.2",
+          "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+          "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+        },
         "blueimp-md5": {
           "version": "2.18.0",
           "resolved": "https://registry.npmjs.org/blueimp-md5/-/blueimp-md5-2.18.0.tgz",
           "integrity": "sha512-vE52okJvzsVWhcgUHOv+69OG3Mdg151xyn41aVQN/5W5S+S43qZhxECtYLAEHMSFWX6Mv5IZrzj3T5+JqXfj5Q=="
         },
         "commander": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
-          "integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q=="
+          "version": "6.2.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
+          "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA=="
+        },
+        "json5": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+          "integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+          "requires": {
+            "minimist": "^1.2.5"
+          }
         },
         "jszip": {
           "version": "3.2.0",
@@ -21486,12 +21516,39 @@
             "pako": "~1.0.2",
             "readable-stream": "~2.3.6",
             "set-immediate-shim": "~1.0.1"
+          },
+          "dependencies": {
+            "pako": {
+              "version": "1.0.11",
+              "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+              "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+            }
+          }
+        },
+        "loader-utils": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^2.1.2"
           }
         },
         "pako": {
-          "version": "1.0.11",
-          "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-          "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.2.tgz",
+          "integrity": "sha512-9e8DRI3+dRLomCmMBAH30B2ejh+blwXr7VmMEx/pVFZlSDA7oyI8uKMhKXr8IrZpoxBF2YlxUvhqRXzTT1i0NA=="
+        },
+        "schema-utils": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.0.0.tgz",
+          "integrity": "sha512-6D82/xSzO094ajanoOSbe4YvXWMfn2A//8Y1+MUqFAJul5Bs+yn36xbK9OtNDcRVSBJ9jjeoXftM6CfztsjOAA==",
+          "requires": {
+            "@types/json-schema": "^7.0.6",
+            "ajv": "^6.12.5",
+            "ajv-keywords": "^3.5.2"
+          }
         },
         "webvr-polyfill": {
           "version": "0.10.12",
@@ -21499,6 +21556,15 @@
           "integrity": "sha512-trDJEVUQnRIVAnmImjEQ0BlL1NfuWl8+eaEdu+bs4g59c7OtETi/5tFkgEFDRaWEYwHntXs/uFF3OXZuutNGGA==",
           "requires": {
             "cardboard-vr-display": "^1.0.19"
+          }
+        },
+        "worker-loader": {
+          "version": "3.0.7",
+          "resolved": "https://registry.npmjs.org/worker-loader/-/worker-loader-3.0.7.tgz",
+          "integrity": "sha512-LjYLuYJw6kqQKDoygpoD5vWeR1CbZjuVSW3/8pFsptMlUl8gatNM/pszhasSDAWt+dYxMipWB6695k+1zId+iQ==",
+          "requires": {
+            "loader-utils": "^2.0.0",
+            "schema-utils": "^3.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "pug": "^3.0.0",
     "pug-plain-loader": "^1.0.0",
     "typeface-roboto": "0.0.75",
-    "vtk.js": "15.4.0",
+    "vtk.js": "16.2.0",
     "vue": "2.6.11",
     "vue-cli-plugin-vuetify": "^2.0.7",
     "vuetify": "2.3.4",

--- a/src/io/GlanceVtkJsReader.js
+++ b/src/io/GlanceVtkJsReader.js
@@ -213,6 +213,12 @@ function vtkGlanceVtkJsReader(publicAPI, model) {
             const pwf = pwfProxy.getPiecewiseFunction();
             pwf.setClamping(scalarOpacity.getClamping());
             const nodes = [];
+
+            const range = scalarOpacity.getRange();
+            pwfProxy.setDataRange(...range);
+
+            const width = range[1] - range[0];
+
             for (
               let nodeIdx = 0;
               nodeIdx < scalarOpacity.getSize();
@@ -220,12 +226,12 @@ function vtkGlanceVtkJsReader(publicAPI, model) {
             ) {
               const node = [];
               scalarOpacity.getNodeValue(nodeIdx, node);
-              nodes.push([...node]);
+              const [x, y, midpoint, sharpness] = node;
+              // x needs to be normalized
+              nodes.push({ x: (x - range[0]) / width, y, midpoint, sharpness });
             }
             pwfProxy.setMode(PiecewiseFunctionProxyConstants.Mode.Nodes);
-            const range = scalarOpacity.getRange();
-            pwfProxy.setDataRange(...range);
-            pwfProxy.setNodes(scalarOpacity.get('nodes').nodes);
+            pwfProxy.setNodes(nodes);
           }
         }
       }


### PR DESCRIPTION
Fixes the loading of opacity transfer functions. It seems I forgot a few things...

Also bumps vtk.js for support with Paraview master.