### PR TITLE
feat(ColorBy): Use default scalars for colorBy

### DIFF
--- a/src/components/controls/ColorBy/script.js
+++ b/src/components/controls/ColorBy/script.js
@@ -326,15 +326,6 @@ export default {
         }
 
         const rep = repGeometry || repVolume;
-        const colorByValue = rep.getColorBy();
-
-        // only get name and location of colorBy array
-        if (colorByValue.length) {
-          this.colorBy = colorByValue.slice(0, 2);
-        } else {
-          // should only happen with geometry
-          this.colorBy = 'solid';
-        }
 
         const propUI = rep
           .getReferenceByName('ui')
@@ -344,6 +335,23 @@ export default {
             propUI.domain.arrays,
             this.available === 'geometry'
           );
+        }
+
+        const colorByValue = rep.getColorBy();
+        const dataset = rep.getInputDataSet();
+        const pointScalars = dataset.getPointData().getScalars();
+        const cellScalars = dataset.getCellData().getScalars();
+
+        // only get name and location of colorBy array
+        if (colorByValue.length) {
+          this.colorBy = colorByValue.slice(0, 2);
+        } else if (pointScalars) {
+          this.colorBy = [pointScalars.getName(), 'pointData'];
+        } else if (cellScalars) {
+          this.colorBy = [cellScalars.getName(), 'cellData'];
+        } else {
+          // should only happen with geometry
+          this.colorBy = 'solid';
         }
 
         if (this.available === 'geometry') {


### PR DESCRIPTION
Datasets that have an active point or cell scalars will now have their coloring default to those scalars.